### PR TITLE
Corrected the DPT6, DPT8 and DPT13 implementation.

### DIFF
--- a/lib/dpts/dpt006.js
+++ b/lib/dpts/dpt006.js
@@ -14,8 +14,7 @@ const { Usage } = require('../constants')
 function decode (dpt, encoded) {
   checkBuffer(encoded, 1)
 
-  const byte1 = encoded.readUInt8(0)
-  return byte1 - 128
+  return encoded.readInt8(0)
 }
 
 /**
@@ -34,8 +33,9 @@ function encode (dpt, decoded) {
     throw new RangeError(`Value out of range (expected -128-127, got ${value})`)
   }
 
-  value += 128
-  return Buffer.alloc(1, value)
+  const buffer = Buffer.alloc(1, 0)
+  buffer.writeInt8(value, 0)
+  return buffer
 }
 
 /**

--- a/lib/dpts/dpt008.js
+++ b/lib/dpts/dpt008.js
@@ -14,7 +14,7 @@ const { Usage } = require('../constants')
 function decode (dpt, encoded) {
   checkBuffer(encoded, 2)
 
-  const value = encoded.readUInt16BE(0)
+  const value = encoded.readInt16BE(0)
 
   switch (dpt) {
     case '8.001':
@@ -23,14 +23,14 @@ function decode (dpt, encoded) {
     case '8.006':
     case '8.007':
     case '8.011':
-      return value - 32768
+      return value
 
     case '8.003':
     case '8.010':
-      return (value - 32768) / 100
+      return value * 10
 
     case '8.004':
-      return (value - 32768) / 10
+      return value * 100
   }
 }
 
@@ -57,9 +57,7 @@ function encode (dpt, decoded) {
       if (value < -32768 || value > 32767) {
         throw new RangeError(`Value out of range (expected -32768-32767, got ${value})`)
       }
-      value += 32768
-      buffer.writeUInt8(value >> 8, 0)
-      buffer.writeUInt8(value & 0xFF, 1)
+      buffer.writeInt16BE(value)
       return buffer
 
     case '8.003':
@@ -67,18 +65,16 @@ function encode (dpt, decoded) {
       if (value < -327.68 || value > 327.67) {
         throw new RangeError(`Value out of range (expected -327.68-327.67, got ${value})`)
       }
-      value = Math.round(value * 100) + 32768
-      buffer.writeUInt8(value >> 8, 0)
-      buffer.writeUInt8(value & 0xFF, 1)
+      value = Math.round(value) / 10
+      buffer.writeInt16BE(value)
       return buffer
 
     case '8.004':
       if (value < -3276.8 || value > 3276.7) {
         throw new RangeError(`Value out of range (expected -3276.8-3276.7, got ${value})`)
       }
-      value = Math.round(value * 10) + 32768
-      buffer.writeUInt8(value >> 8, 0)
-      buffer.writeUInt8(value & 0xFF, 1)
+      value = Math.round(value) / 100
+      buffer.writeInt16BE(value)
       return buffer
   }
 }

--- a/lib/dpts/dpt013.js
+++ b/lib/dpts/dpt013.js
@@ -14,8 +14,8 @@ const { Usage } = require('../constants')
 function decode (dpt, encoded) {
   checkBuffer(encoded, 4)
 
-  let value = encoded.readUInt32BE()
-  value -= 2147483648
+  let value = encoded.readInt32BE()
+
   return value
 }
 
@@ -35,10 +35,8 @@ function encode (dpt, decoded) {
     throw new RangeError(`Value out of range (expected -2147483648-2147483647, got ${value})`)
   }
 
-  value += 2147483648
-
   const buffer = Buffer.alloc(4, 0)
-  buffer.writeUInt32BE(value, 0)
+  buffer.writeInt32BE(value, 0)
   return buffer
 }
 

--- a/tests/dpt006.spec.js
+++ b/tests/dpt006.spec.js
@@ -3,10 +3,10 @@ const knxDatapoints = require('../')
 
 suite('dpt6', () => {
   test('decode', () => {
-    assert.strictEqual(knxDatapoints.decode('6.001', Buffer.from('00', 'hex')), -128)
-    assert.strictEqual(knxDatapoints.decode('6.001', Buffer.from('64', 'hex')), -28)
-    assert.strictEqual(knxDatapoints.decode('6.001', Buffer.from('C8', 'hex')), 72)
-    assert.strictEqual(knxDatapoints.decode('6.001', Buffer.from('FF', 'hex')), 127)
+    assert.strictEqual(knxDatapoints.decode('6.001', Buffer.from('80', 'hex')), -128)
+    assert.strictEqual(knxDatapoints.decode('6.001', Buffer.from('E4', 'hex')), -28)
+    assert.strictEqual(knxDatapoints.decode('6.001', Buffer.from('48', 'hex')), 72)
+    assert.strictEqual(knxDatapoints.decode('6.001', Buffer.from('7F', 'hex')), 127)
 
     assert.throws(() => { knxDatapoints.decode('6.001', Buffer.alloc(0)) }, Error)
     assert.throws(() => { knxDatapoints.decode('6.001', Buffer.alloc(2, 0)) }, Error)
@@ -14,10 +14,10 @@ suite('dpt6', () => {
   })
 
   test('encode', () => {
-    assert.ok(knxDatapoints.encode('6.001', -128).equals(Buffer.from('00', 'hex')))
-    assert.ok(knxDatapoints.encode('6.001', -28).equals(Buffer.from('64', 'hex')))
-    assert.ok(knxDatapoints.encode('6.001', 72).equals(Buffer.from('C8', 'hex')))
-    assert.ok(knxDatapoints.encode('6.001', 127).equals(Buffer.from('FF', 'hex')))
+    assert.ok(knxDatapoints.encode('6.001', -128).equals(Buffer.from('80', 'hex')))
+    assert.ok(knxDatapoints.encode('6.001', -28).equals(Buffer.from('E4', 'hex')))
+    assert.ok(knxDatapoints.encode('6.001', 72).equals(Buffer.from('48', 'hex')))
+    assert.ok(knxDatapoints.encode('6.001', 127).equals(Buffer.from('7F', 'hex')))
 
     assert.throws(() => { knxDatapoints.encode('6.001', -129) }, RangeError)
     assert.throws(() => { knxDatapoints.encode('6.001', 128) }, RangeError)

--- a/tests/dpt008.spec.js
+++ b/tests/dpt008.spec.js
@@ -4,23 +4,23 @@ const knxDatapoints = require('../')
 suite('dpt8', () => {
   test('decode', () => {
     ['8.001', '8.002', '8.005', '8.006', '8.007', '8.011'].forEach((dpt) => {
-      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('0000', 'hex')), -32768)
-      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('6464', 'hex')), -7068)
-      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('C8C8', 'hex')), 18632)
-      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('FFFF', 'hex')), 32767)
+      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('8000', 'hex')), -32768)
+      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('E464', 'hex')), -7068)
+      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('48C8', 'hex')), 18632)
+      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('7FFF', 'hex')), 32767)
     });
 
     ['8.003', '8.010'].forEach((dpt) => {
-      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('0000', 'hex')), -327.68)
-      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('6464', 'hex')), -70.68)
-      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('C8C8', 'hex')), 186.32)
-      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('FFFF', 'hex')), 327.67)
+      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('FFE0', 'hex')), -320)
+      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('FFF9', 'hex')), -70)
+      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('0012', 'hex')), 180)
+      assert.strictEqual(knxDatapoints.decode(dpt, Buffer.from('0020', 'hex')), 320)
     })
 
-    assert.strictEqual(knxDatapoints.decode('8.004', Buffer.from('0000', 'hex')), -3276.8)
-    assert.strictEqual(knxDatapoints.decode('8.004', Buffer.from('6464', 'hex')), -706.8)
-    assert.strictEqual(knxDatapoints.decode('8.004', Buffer.from('C8C8', 'hex')), 1863.2)
-    assert.strictEqual(knxDatapoints.decode('8.004', Buffer.from('FFFF', 'hex')), 3276.7)
+    assert.strictEqual(knxDatapoints.decode('8.004', Buffer.from('FFE0', 'hex')), -3200)
+    assert.strictEqual(knxDatapoints.decode('8.004', Buffer.from('FFF9', 'hex')), -700)
+    assert.strictEqual(knxDatapoints.decode('8.004', Buffer.from('0012', 'hex')), 1800)
+    assert.strictEqual(knxDatapoints.decode('8.004', Buffer.from('0020', 'hex')), 3200)
 
     assert.throws(() => { knxDatapoints.decode('8.001', Buffer.alloc(0)) }, Error)
     assert.throws(() => { knxDatapoints.decode('8.001', Buffer.alloc(3)) }, Error)
@@ -29,27 +29,27 @@ suite('dpt8', () => {
 
   test('encode', () => {
     ['8.001', '8.002', '8.005', '8.006', '8.007', '8.011'].forEach((dpt) => {
-      assert.ok(knxDatapoints.encode(dpt, -32768).equals(Buffer.from('0000', 'hex')))
-      assert.ok(knxDatapoints.encode(dpt, -7068).equals(Buffer.from('6464', 'hex')))
-      assert.ok(knxDatapoints.encode(dpt, 18632).equals(Buffer.from('C8C8', 'hex')))
-      assert.ok(knxDatapoints.encode(dpt, 32767).equals(Buffer.from('FFFF', 'hex')))
+      assert.ok(knxDatapoints.encode(dpt, -32768).equals(Buffer.from('8000', 'hex')))
+      assert.ok(knxDatapoints.encode(dpt, -7068).equals(Buffer.from('E464', 'hex')))
+      assert.ok(knxDatapoints.encode(dpt, 18632).equals(Buffer.from('48C8', 'hex')))
+      assert.ok(knxDatapoints.encode(dpt, 32767).equals(Buffer.from('7FFF', 'hex')))
       assert.throws(() => { knxDatapoints.encode(dpt, -32769) }, RangeError)
       assert.throws(() => { knxDatapoints.encode(dpt, 32768) }, RangeError)
     });
 
     ['8.003', '8.010'].forEach((dpt) => {
-      assert.ok(knxDatapoints.encode(dpt, -327.68).equals(Buffer.from('0000', 'hex')))
-      assert.ok(knxDatapoints.encode(dpt, -70.68).equals(Buffer.from('6464', 'hex')))
-      assert.ok(knxDatapoints.encode(dpt, 186.32).equals(Buffer.from('C8C8', 'hex')))
-      assert.ok(knxDatapoints.encode(dpt, 327.67).equals(Buffer.from('FFFF', 'hex')))
+      assert.ok(knxDatapoints.encode(dpt, -327.68).equals(Buffer.from('FFE0', 'hex')))
+      assert.ok(knxDatapoints.encode(dpt, -70.68).equals(Buffer.from('FFF9', 'hex')))
+      assert.ok(knxDatapoints.encode(dpt, 186.32).equals(Buffer.from('0012', 'hex')))
+      assert.ok(knxDatapoints.encode(dpt, 327.67).equals(Buffer.from('0020', 'hex')))
       assert.throws(() => { knxDatapoints.encode(dpt, -327.69) }, RangeError)
       assert.throws(() => { knxDatapoints.encode(dpt, 327.68) }, RangeError)
     })
 
-    assert.ok(knxDatapoints.encode('8.004', -3276.8).equals(Buffer.from('0000', 'hex')))
-    assert.ok(knxDatapoints.encode('8.004', -706.8).equals(Buffer.from('6464', 'hex')))
-    assert.ok(knxDatapoints.encode('8.004', 1863.2).equals(Buffer.from('C8C8', 'hex')))
-    assert.ok(knxDatapoints.encode('8.004', 3276.7).equals(Buffer.from('FFFF', 'hex')))
+    assert.ok(knxDatapoints.encode('8.004', -3276.8).equals(Buffer.from('FFE0', 'hex')))
+    assert.ok(knxDatapoints.encode('8.004', -706.8).equals(Buffer.from('FFF9', 'hex')))
+    assert.ok(knxDatapoints.encode('8.004', 1863.2).equals(Buffer.from('0012', 'hex')))
+    assert.ok(knxDatapoints.encode('8.004', 3276.7).equals(Buffer.from('0020', 'hex')))
     assert.throws(() => { knxDatapoints.encode('8.004', -3276.9) }, RangeError)
     assert.throws(() => { knxDatapoints.encode('8.004', 3276.8) }, RangeError)
   })

--- a/tests/dpt013.spec.js
+++ b/tests/dpt013.spec.js
@@ -3,8 +3,8 @@ const knxDatapoints = require('../')
 
 suite('dpt13', () => {
   test('decode', () => {
-    assert.strictEqual(knxDatapoints.decode('13.001', Buffer.from('00000000', 'hex')), -2147483648)
-    assert.strictEqual(knxDatapoints.decode('13.001', Buffer.from('FFFFFFFF', 'hex')), 2147483647)
+    assert.strictEqual(knxDatapoints.decode('13.001', Buffer.from('0000000A', 'hex')), 10)
+    assert.strictEqual(knxDatapoints.decode('13.001', Buffer.from('FFFFFFF6', 'hex')), -10)
 
     assert.throws(() => { knxDatapoints.decode('13.001', Buffer.alloc(0)) }, Error)
     assert.throws(() => { knxDatapoints.decode('13.001', Buffer.alloc(5)) }, Error)
@@ -12,8 +12,8 @@ suite('dpt13', () => {
   })
 
   test('encode', () => {
-    assert.ok(knxDatapoints.encode('13.001', -2147483648).equals(Buffer.from('00000000', 'hex')))
-    assert.ok(knxDatapoints.encode('13.001', 2147483647).equals(Buffer.from('FFFFFFFF', 'hex')))
+    assert.ok(knxDatapoints.encode('13.001', 10).equals(Buffer.from('0000000A', 'hex')))
+    assert.ok(knxDatapoints.encode('13.001', -10).equals(Buffer.from('FFFFFFF6', 'hex')))
 
     assert.throws(() => knxDatapoints.encode('13.001', -2147483649), RangeError)
     assert.throws(() => knxDatapoints.encode('13.001', 2147483648), RangeError)


### PR DESCRIPTION
The library incorrectly encoded and decoded DPT6, DPT8 and DPT13 values. 

KNX uses two's complement for encoding 32-bit signed integers. Instead of subtracting 2³¹ when decoding, we simply use JavaScript's built-in `readInt32BE()` function.

I also updated the tests for DPT6, 8 and 13. I published the human-readable values on the KNX bus using ETS and then pasted the hexadecimal value into the test, because ETS can be used as a reference for correct encoding/decoding.